### PR TITLE
Fix bug in enrichment calculation

### DIFF
--- a/TFEA/enrichment.py
+++ b/TFEA/enrichment.py
@@ -293,7 +293,7 @@ def get_auc_gc(distances, fimo_motifs=None):
         binwidth = 1.0/float(len(distances_abs))
         normalized_score = [(float(x)/total)*binwidth for x in score]
         cumscore = np.cumsum(normalized_score)
-        trend = np.append(np.arange(0,1,1.0/float(len(cumscore)))[1:], 1.0)
+        trend = np.append(np.arange(0,1,1.0/float(len(cumscore) - 1)), 1.0)
         trend = [x*binwidth for x in trend]
 
         #The AUC is the relative to the "random" line
@@ -358,7 +358,7 @@ def auc_simulate_and_plot(distances, use_config=True, output_type=None,
         normalized_score = np.multiply(np.divide(score, total), binwidth)
         #[(float(x)/total)*binwidth for x in score]
         cumscore = np.cumsum(normalized_score)
-        trend = np.append(np.arange(0,1,1.0/float(len(cumscore)))[1:], 1.0)
+        trend = np.append(np.arange(0,1,1.0/float(len(cumscore) - 1)), 1.0)
         trend = np.multiply(trend, binwidth)
         # trend = [x*binwidth for x in trend]
 


### PR DESCRIPTION
The patch changes the 1-1 line calculation from `1.0/float(len(cumscore)))[1:]` to `1.0/float(len(cumscore) - 1))` in the 2 places that it occurs in `enrichment.py`

This change fixes a small bug in the enrichment calculations that caused the 1-1 line that enrichment scores were calculated off of to be skewed so that a true 1-1 line gave a negative enrichment score. This should correct the issue and may reduce the number of things called as significantly upregulated.

